### PR TITLE
Use strict types throughout decoding Base16

### DIFF
--- a/Text/ProtocolBuffers/ProtoJSON.hs
+++ b/Text/ProtocolBuffers/ProtoJSON.hs
@@ -8,8 +8,9 @@ import qualified Data.Vector as V
 import Text.ProtocolBuffers.Basic
 import Text.Read (readEither)
 
-import qualified Data.ByteString.Base16.Lazy as BL16
-import qualified Data.Text.Lazy.Encoding as TL
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.Text.Encoding as T
 
 {-# INLINE objectNoEmpty #-}
 objectNoEmpty :: [Pair] -> Value
@@ -39,12 +40,12 @@ parseJSONBool _ = fail "Expected Bool"
 
 {-# INLINE toJSONByteString #-}
 toJSONByteString :: ByteString -> Value
-toJSONByteString bs = object [("payload", toJSON . TL.decodeUtf8 . BL16.encode $ bs)]
+toJSONByteString bs = object [("payload", String . T.decodeUtf8 . B16.encode . BL.toStrict $ bs)]
 
 {-# INLINE parseJSONByteString #-}
 parseJSONByteString :: Value -> Parser ByteString
 parseJSONByteString = withObject "bytes" $ \o -> do
     t <- o .: "payload"
-    case BL16.decode (TL.encodeUtf8 t) of
-      (bs, "") -> return bs
+    case B16.decode (T.encodeUtf8 t) of
+      (bs, "") -> return (BL.fromStrict bs)
       _ -> fail "Failed to parse base16."

--- a/protocol-buffers.cabal
+++ b/protocol-buffers.cabal
@@ -35,7 +35,7 @@ Library
                    Text.ProtocolBuffers.ProtoJSON
 
   build-depends: base >= 4.7.0 && < 5,
-                 aeson,
+                 aeson >= 1.1.0.0,
                  array,
                  base16-bytestring,
                  text,

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,7 +1,37 @@
+flags:
+  time-locale-compat:
+    old-locale: false
 packages:
-- '.'
+- .
 - descriptor/
 - hprotoc/
 extra-deps:
-- haskell-src-exts-1.18.1
-resolver: lts-3.5
+- aeson-1.1.0.0 # First version that should work
+- attoparsec-0.13.2.2
+- base-compat-0.9.3
+- base16-bytestring-0.1.1.6
+- cpphs-1.20.8
+- dlist-0.8.0.4
+- fail-4.9.0.0
+- hashable-1.2.7.0
+- haskell-src-exts-1.18.1 # First version that should work
+- integer-logarithms-1.0.2.1
+- mtl-2.2.2
+- old-locale-1.0.0.7
+- old-time-1.1.0.3
+- parsec-3.1.13.0
+- polyparse-1.12
+- primitive-0.6.4.0
+- random-1.1
+- scientific-0.3.6.2
+- semigroups-0.18.4
+- syb-0.7
+- tagged-0.8.5
+- text-1.2.3.0
+- time-locale-compat-0.1.1.4
+- transformers-compat-0.5.1.4
+- unordered-containers-0.2.9.0
+- utf8-string-1.0.1.1
+- uuid-types-1.0.3
+- vector-0.12.0.1
+resolver: ghc-7.10


### PR DESCRIPTION
This somehow triggered a bug. I should find out what exactly that was.